### PR TITLE
Removes the jasper option from Imagemagick and bumps to latest patch release

### DIFF
--- a/graphics/ImageMagick/Makefile.common
+++ b/graphics/ImageMagick/Makefile.common
@@ -7,7 +7,7 @@
 # used by graphics/p5-PerlMagick/Makefile
 
 IM_MAJOR_VER=		7.0.7
-IM_MINOR_VER=		7
+IM_MINOR_VER=		8
 IM_MAJOR_LIB_VER=	7
 
 .if (${IM_MINOR_VER} != NONE)

--- a/graphics/ImageMagick/buildlink3.mk
+++ b/graphics/ImageMagick/buildlink3.mk
@@ -15,8 +15,8 @@ pkgbase := ImageMagick
 .if !empty(PKG_BUILD_OPTIONS.ImageMagick:Mdjvu)
 .include "../../graphics/djvulibre-lib/buildlink3.mk"
 .endif
-.if !empty(PKG_BUILD_OPTIONS.ImageMagick:Mjasper)
-.include "../../graphics/jasper/buildlink3.mk"
+.if !empty(PKG_BUILD_OPTIONS.ImageMagick:Mjp2)
+.include "../../graphics/openjpeg/buildlink3.mk"
 .endif
 .if !empty(PKG_BUILD_OPTIONS.ImageMagick:Mopenexr)
 .include "../../graphics/openexr/buildlink3.mk"

--- a/graphics/ImageMagick/distinfo
+++ b/graphics/ImageMagick/distinfo
@@ -1,6 +1,6 @@
 $NetBSD: distinfo,v 1.173 2017/10/10 19:47:50 tez Exp $
 
-SHA1 (ImageMagick-7.0.7-7.tar.xz) = da3a83be342b37c5b48eea2daf85d10e12dec981
-RMD160 (ImageMagick-7.0.7-7.tar.xz) = 7828840bf718613eb9a3d1f2371114acc138923e
-SHA512 (ImageMagick-7.0.7-7.tar.xz) = ab18734a8569c1fc59dd3420dcad3c00a1bec016468a5cc2ddc4c84a39867deceed0aa01aa0ced410504fb9d0e228f6f6e69b3bbe1514b9e55fd0068f3acc521
-Size (ImageMagick-7.0.7-7.tar.xz) = 8559844 bytes
+SHA1 (ImageMagick-7.0.7-8.tar.xz) = fa50b581eb480330d382ac6b307212e25e74b81d
+RMD160 (ImageMagick-7.0.7-8.tar.xz) = 95b3c0c0229851764971959b864156c9ae9363c8
+SHA512 (ImageMagick-7.0.7-8.tar.xz) = 0852df3bc996032a713ce6dc274cc36c3818c1c8304223de391e58bce8230aa12ac9778b4b28278c0ab4e42f2a7b4094052a5e4e6e4208329848948237fb41d2
+Size (ImageMagick-7.0.7-8.tar.xz) = 8797060 bytes

--- a/graphics/ImageMagick/options.mk
+++ b/graphics/ImageMagick/options.mk
@@ -1,8 +1,8 @@
 # $NetBSD: options.mk,v 1.17 2014/10/12 18:55:14 dholland Exp $
 
 PKG_OPTIONS_VAR=	PKG_OPTIONS.ImageMagick
-PKG_SUPPORTED_OPTIONS=	x11 jasper djvu openexr wmf
-PKG_SUGGESTED_OPTIONS=	x11 jasper
+PKG_SUPPORTED_OPTIONS=	x11 djvu jp2 openexr wmf
+PKG_SUGGESTED_OPTIONS=	x11
 
 .include "../../mk/bsd.options.mk"
 
@@ -14,9 +14,8 @@ PKG_SUGGESTED_OPTIONS=	x11 jasper
 CONFIGURE_ARGS+=	--without-x
 .endif
 
-.if !empty(PKG_OPTIONS:Mjasper)
-BUILDLINK_API_DEPENDS.jasper+=	jasper>=1.701.0
-.include "../../graphics/jasper/buildlink3.mk"
+.if !empty(PKG_OPTIONS:Mjp2)
+.include "../../graphics/openjpeg/buildlink3.mk"
 CONFIGURE_ARGS+=	--with-jp2
 .else
 CONFIGURE_ARGS+=	--without-jp2


### PR DESCRIPTION
Remove the jasper option to link against graphics/jasper. With
this options set (the package default), this causes ImageMagick to pull in graphics/jasper
at install. However, ImageMagick does not actually link against graphics/jasper
and has not done since < 6.8 versions.

jasper was linked in to support the jp2 format, which it now supports
via linking against openjpeg.

So we add the option 'jp2' which links against openjpeg. We also remove
it from the suggested options as it's not a common format and hasn't
actually been supported in pkgsrc ImageMagick for some time.

We also bump the latest minor patch release while in here.

The intention is to also backport these changes to LTS branches. The LTS release are affected by security issues in imagemagick and japser. These changes should fix the imagemagick issues and allow jasper to uninstalled in the majority of cases.