### PR TITLE
Remove jasper option from ImageMagick6

### DIFF
--- a/graphics/ImageMagick6/Makefile.common
+++ b/graphics/ImageMagick6/Makefile.common
@@ -4,7 +4,7 @@
 # since they disappear immediately when new releases happen.
 
 IM_MAJOR_VER=		6.9.9
-IM_MINOR_VER=		12
+IM_MINOR_VER=		20
 IM_MAJOR_LIB_VER=	6
 
 .if (${IM_MINOR_VER} != NONE)

--- a/graphics/ImageMagick6/PLIST
+++ b/graphics/ImageMagick6/PLIST
@@ -1213,3 +1213,4 @@ share/examples/ImageMagick6/type-dejavu.xml
 share/examples/ImageMagick6/type-ghostscript.xml
 share/examples/ImageMagick6/type-windows.xml
 share/examples/ImageMagick6/type.xml
+share/examples/ImageMagick6/type-urw-base35.xml

--- a/graphics/ImageMagick6/buildlink3.mk
+++ b/graphics/ImageMagick6/buildlink3.mk
@@ -15,8 +15,8 @@ pkgbase := ImageMagick6
 .if !empty(PKG_BUILD_OPTIONS.ImageMagick6:Mdjvu)
 .include "../../graphics/djvulibre-lib/buildlink3.mk"
 .endif
-.if !empty(PKG_BUILD_OPTIONS.ImageMagick6:Mjasper)
-.include "../../graphics/jasper/buildlink3.mk"
+.if !empty(PKG_BUILD_OPTIONS.ImageMagick6:Mjp2)
+.include "../../graphics/openjpeg/buildlink3.mk"
 .endif
 .if !empty(PKG_BUILD_OPTIONS.ImageMagick6:Mopenexr)
 .include "../../graphics/openexr/buildlink3.mk"

--- a/graphics/ImageMagick6/distinfo
+++ b/graphics/ImageMagick6/distinfo
@@ -1,7 +1,7 @@
 $NetBSD: distinfo,v 1.7 2017/09/11 01:18:45 ryoon Exp $
 
-SHA1 (ImageMagick-6.9.9-12.tar.xz) = 7f9d9ec64e7054c698d691bbb474500d3e29115b
-RMD160 (ImageMagick-6.9.9-12.tar.xz) = 9f105944d71ec580353712eb83c026a4fefbf202
-SHA512 (ImageMagick-6.9.9-12.tar.xz) = b4a876ce6310c0cbcb915ab1f7bfbeebdce47c7758f43e563cba01b5673db387768b6e65efe8915be8e06745c4a5ed2691a761baf4d52c04126a7c98362e3ef2
-Size (ImageMagick-6.9.9-12.tar.xz) = 8788428 bytes
+SHA1 (ImageMagick-6.9.9-20.tar.xz) = 551b9684a0ec02b8993f59ed127cd13d976516a6
+RMD160 (ImageMagick-6.9.9-20.tar.xz) = f52fe28e5988d08083428d1a21fae8921f9526b0
+SHA512 (ImageMagick-6.9.9-20.tar.xz) = 36c241490ee41de5cd72e5bc297ac2353a0d4574337776445798b0c5823f491304c3f3a728d420d03f66b652eafcdb68ec2992347321ac3919c1d72c0afdb849
+Size (ImageMagick-6.9.9-20.tar.xz) = 8994128 bytes
 SHA1 (patch-Makefile.in) = bb747b5e062f2a59e307289b5b33861dd5f96ab0

--- a/graphics/ImageMagick6/options.mk
+++ b/graphics/ImageMagick6/options.mk
@@ -1,8 +1,8 @@
 # $NetBSD: options.mk,v 1.1 2016/05/25 12:41:17 ryoon Exp $
 
 PKG_OPTIONS_VAR=	PKG_OPTIONS.ImageMagick
-PKG_SUPPORTED_OPTIONS=	x11 jasper djvu openexr wmf
-PKG_SUGGESTED_OPTIONS=	x11 jasper
+PKG_SUPPORTED_OPTIONS=	x11 jp2 djvu openexr wmf
+PKG_SUGGESTED_OPTIONS=	x11
 
 .include "../../mk/bsd.options.mk"
 
@@ -14,9 +14,8 @@ PKG_SUGGESTED_OPTIONS=	x11 jasper
 CONFIGURE_ARGS+=	--without-x
 .endif
 
-.if !empty(PKG_OPTIONS:Mjasper)
-BUILDLINK_API_DEPENDS.jasper+=	jasper>=1.701.0
-.include "../../graphics/jasper/buildlink3.mk"
+.if !empty(PKG_OPTIONS:Mjp2)
+.include "../../graphics/openjpeg/buildlink3.mk"
 CONFIGURE_ARGS+=	--with-jp2
 .else
 CONFIGURE_ARGS+=	--without-jp2


### PR DESCRIPTION
Remove the jasper option to link against graphics/jasper. With
the default options, this causes ImageMagick to pull in graphics/jasper
at install. However, ImageMagick does not actually link against
graphics/jasper and has not done since < 6.8 versions.

jasper was linked in to support the jp2 format, which it now supports
via linking against openjpeg.

So we add the option 'jp2' which links against openjpeg. We also remove
it from the suggested options as it's not a common format and hasn't
actually been supported in pkgsrc ImageMagick for some time.

We also bump the latest minor patch release while in here.

The intention is to also backport this change to the LTS branches to fix security issues with imagemagick, and allow libjasper to uninstalled in the majority of cases (which also has security issues)