### PR TITLE
Fix compilation of fcgiwrap

### DIFF
--- a/www/fcgiwrap/Makefile
+++ b/www/fcgiwrap/Makefile
@@ -17,6 +17,7 @@ GNU_CONFIGURE=	yes
 USE_TOOLS+=	automake autoreconf pkg-config
 
 LDFLAGS.SunOS+=	-lsocket -lnsl
+CFLAGS.SunOS+= -Wimplicit-fallthrough=0
 
 pre-configure:
 	cd ${WRKSRC} && autoreconf -i


### PR DESCRIPTION
fcgiwrap in trunk and 2018Q3 won't compile and therefore doesn't result generate a successful binary for pkgin.

This change disables the warning (now error because of compilation settings) for implicit fallthrough.  The line immediately preceding the warning is a method that calls exit explicitly.

This can safely be brought to both trunk and 2018Q3.