### PR TITLE
Re-enable mod_proxy_html

### DIFF
--- a/www/apache24/Makefile
+++ b/www/apache24/Makefile
@@ -30,6 +30,7 @@ CONFIGURE_ARGS+=	--enable-mods-shared=all
 CONFIGURE_ARGS+=	--enable-so
 CONFIGURE_ARGS+=	--with-apr=${BUILDLINK_PREFIX.apr}
 CONFIGURE_ARGS+=	--with-apr-util=${BUILDLINK_PREFIX.apr-util}
+CONFIGURE_ARGS+=	--with-libxml2=${BUILDLINK_PREFIX.libxml2}
 CONFIGURE_ARGS+=	--with-port=80
 CONFIGURE_ENV+=		perlbin=${PERL5:Q}
 CONFIGURE_ENV+=		ac_cv_path_RSYNC=/nonexistent
@@ -50,11 +51,12 @@ BUILDLINK_API_DEPENDS.apr-util+=	apr-util>=1.5.3
 .include "../../devel/pcre/buildlink3.mk"
 .include "../../security/openssl/buildlink3.mk"
 .include "../../textproc/expat/buildlink3.mk"
+.include "../../textproc/libxml2/buildlink3.mk"
 .include "../../mk/dlopen.buildlink3.mk"
 .include "../../mk/pthread.buildlink3.mk"
 
-CONFIGURE_ARGS+=	--disable-xml2enc
-CONFIGURE_ARGS+=	--disable-proxy-html
+CONFIGURE_ARGS+=	--enable-xml2enc
+CONFIGURE_ARGS+=	--enable-proxy-html
 CONFIGURE_ARGS+=	--enable-proxy-fdpass
 
 DFLT_APACHE_MODULES+=	all

--- a/www/apache24/PLIST
+++ b/www/apache24/PLIST
@@ -1,4 +1,4 @@
-@comment $NetBSD: PLIST,v 1.27 2018/10/24 10:08:00 adam Exp $
+@comment $NetBSD$
 bin/ab
 bin/apxs
 bin/dbmmanage
@@ -150,6 +150,7 @@ lib/httpd/mod_proxy_fcgi.so
 lib/httpd/mod_proxy_fdpass.so
 lib/httpd/mod_proxy_ftp.so
 lib/httpd/mod_proxy_hcheck.so
+lib/httpd/mod_proxy_html.so
 lib/httpd/mod_proxy_http.so
 lib/httpd/mod_proxy_scgi.so
 lib/httpd/mod_proxy_uwsgi.so
@@ -183,6 +184,7 @@ lib/httpd/mod_usertrack.so
 lib/httpd/mod_version.so
 lib/httpd/mod_vhost_alias.so
 lib/httpd/mod_watchdog.so
+lib/httpd/mod_xml2enc.so
 libexec/cgi-bin/printenv
 libexec/cgi-bin/printenv.vbs
 libexec/cgi-bin/printenv.wsf

--- a/www/apache24/buildlink3.mk
+++ b/www/apache24/buildlink3.mk
@@ -29,6 +29,7 @@ CONFIGURE_ARGS+=	--with-apxs2=${APXS:Q}
 
 .include "../../devel/apr/buildlink3.mk"
 .include "../../devel/apr-util/buildlink3.mk"
+.include "../../textproc/libxml2/buildlink3.mk"
 .endif # APACHE_BUILDLINK3_MK
 
 BUILDLINK_TREE+=	-apache


### PR DESCRIPTION
mod_proxy_html was disabled nearly 7 years ago in commit [e803b468800](https://github.com/joyent/pkgsrc/commit/e803b4688002dd621c04449bc438d5d696332b71). As far as I can find, the only context for the above change is here:

[https://mail-index.netbsd.org/tech-pkg/2012/04/18/msg009003.html](https://mail-index.netbsd.org/tech-pkg/2012/04/18/msg009003.html)

This pull request re-enables mod_proxy_html and (I think) properly configures the necessary dependency on libxml2.

This is my first time attempting a pkgsrc change; feedback welcome!