### PR TITLE
Add libraries for php-imagick

### DIFF
--- a/graphics/php-imagick/Makefile
+++ b/graphics/php-imagick/Makefile
@@ -15,5 +15,8 @@ CONFIGURE_ARGS+=	--with-imagick=${BUILDLINK_PREFIX.ImageMagick}
 TEST_TARGET=		test
 
 .include "../../graphics/ImageMagick/buildlink3.mk"
+.include "../../devel/pcre/buildlink3.mk"
+.include "../../devel/glib2/buildlink3.mk"
+.include "../../graphics/liblqr/buildlink3.mk"
 .include "../../lang/php/ext.mk"
 .include "../../mk/bsd.pkg.mk"


### PR DESCRIPTION
The package php-imagick isn't in the 2018Q4 LTS package builds.   It appears to be because the package wasn't building, because it had a few libraries that needed to be linked in.

I've tested this using the pkgbuild 18.4 image, on php71 and php73.  The builds work, I have not extensively tested the resulting package.

