### PR TITLE
net/tor: update to v0.4.1.5 and add SMF support.

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -1,6 +1,6 @@
-# $NetBSD: Makefile,v 1.140 2019/05/03 08:45:51 wiz Exp $
+# $NetBSD: Makefile,v 1.137 2019/02/22 08:47:51 adam Exp $
 
-DISTNAME=	tor-0.4.0.5
+DISTNAME=	tor-0.4.1.5
 CATEGORIES=	net security
 MASTER_SITES=	https://dist.torproject.org/
 
@@ -21,7 +21,7 @@ TEST_TARGET=		check
 
 TOR_USER?=		tor
 TOR_GROUP?=		tor
-PKG_GECOS.${TOR_USER}=	Torifier
+PKG_GECOS.${TOR_USER}=	The Onion Router
 PKG_HOME.${TOR_USER}=	${VARBASE}/chroot/tor
 BUILD_DEFS+=		VARBASE
 PKG_SYSCONFSUBDIR=	tor

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -1,4 +1,4 @@
-# $NetBSD: Makefile,v 1.137 2019/02/22 08:47:51 adam Exp $
+# $NetBSD: Makefile,v 1.140 2019/05/03 08:45:51 wiz Exp $
 
 DISTNAME=	tor-0.4.1.5
 CATEGORIES=	net security

--- a/net/tor/distinfo
+++ b/net/tor/distinfo
@@ -1,6 +1,6 @@
-$NetBSD: distinfo,v 1.99 2019/05/03 08:45:51 wiz Exp $
+$NetBSD: distinfo,v 1.97 2019/02/22 08:47:51 adam Exp $
 
-SHA1 (tor-0.4.0.5.tar.gz) = be1307f0c78119038dc194c5f1c233b3e658d3bc
-RMD160 (tor-0.4.0.5.tar.gz) = cc0bead52c77d0cb7f65c7c083c48d3810514287
-SHA512 (tor-0.4.0.5.tar.gz) = f6bccc52aaa436a501077b0891ecd3a9779f288b3b15fd76fa2c612e60aba04763b5951f55b2357e6271797b2f924bee9a6d2c1ee20419daa02d9d38ec68510b
-Size (tor-0.4.0.5.tar.gz) = 7203877 bytes
+SHA1 (tor-0.4.1.5.tar.gz) = a65def67cdc70565717aefa5956ec5fdcbbdd959
+RMD160 (tor-0.4.1.5.tar.gz) = 3bb1881407e41725e9013739b71372712571be57
+SHA512 (tor-0.4.1.5.tar.gz) = 33d30f5fd2a92dfcb28d97c76c9d396d3eda27036b01c3a678428e878f046e45a87c2d42de0c1b8ba672568d75b08ba4cbf56d1aa50acd34c0d174180faace6e
+Size (tor-0.4.1.5.tar.gz) = 7378436 bytes

--- a/net/tor/files/smf/manifest.xml
+++ b/net/tor/files/smf/manifest.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<service_bundle type="manifest" name="@SMF_NAME@">
+    <service name="@SMF_PREFIX@/@SMF_NAME@" type="service" version="0.1">
+        <create_default_instance enabled="false"/>
+        <single_instance/>
+
+        <dependency name="network" grouping="require_all" restart_on="error" type="service">
+            <service_fmri value="svc:/milestone/network:default"/>
+        </dependency>
+
+        <dependency name="filesystem" grouping="require_all" restart_on="error" type="service">
+            <service_fmri value="svc:/system/filesystem/local"/>
+        </dependency>
+        
+        <method_context>
+            <method_credential user="@TOR_USER@" group="@TOR_GROUP@"/>
+        </method_context>
+
+        <exec_method type="method" name="start" exec="@PREFIX@/bin/tor --RunAsDaemon 1 --DataDirectory @PKG_HOME@" timeout_seconds="60"/>
+        <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60"/>
+
+        <property_group name="startd" type="framework">
+            <propval name="duration" type="astring" value="contract"/>
+            <propval name="ignore_error" type="astring" value="core,signal"/>
+        </property_group>
+
+        <property_group name="application" type="application">
+            <propval name="config_file" type="astring" value="@PKG_SYSCONFDIR@/torrc"/>
+        </property_group>
+        
+        <stability value="Evolving"/>
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">
+                    The Onion Router
+                </loctext>
+            </common_name>
+        </template>
+    </service>
+</service_bundle>


### PR DESCRIPTION
This commit adds SMF support for Tor and updates the version to the one matching NetBSD's pkgsrc.

Bear in mind that at the moment there is no available binary tor package for SmartOS, the build is failing: https://mail-index.netbsd.org/pkgsrc-users/2019/08/25/msg029234.html

No problem in my local build zone though.