### PR TITLE
gitea: use gitea Makefile, fix builtin static files

### DIFF
--- a/www/gitea/Makefile
+++ b/www/gitea/Makefile
@@ -1,4 +1,4 @@
-# $NetBSD: Makefile,v 1.33 2020/05/17 14:50:40 nia Exp $
+# $NetBSD: Makefile,v 1.34 2020/05/20 22:37:40 teutat3s Exp $
 
 DISTNAME=	gitea-1.11.5
 MASTER_SITES=	${MASTER_SITE_GITHUB:=go-gitea/}
@@ -16,17 +16,13 @@ GO_SRCPATH=		code.gitea.io/gitea
 .include "../../lang/go/go-vars.mk"
 .include "options.mk"
 
-.if !empty(GO_TAGS)
-GO_BUILD_PATTERN+=	-tags "${GO_TAGS}"
-.endif
-
-GO_BUILD_PATTERN+=	${GO_SRCPATH}
-
 BUILD_DEFS+=	VARBASE GITEA_USER GITEA_GROUP
 
 EXTRACT_USING=	bsdtar
-USE_TOOLS+=	pax
+USE_TOOLS+=	gmake ggrep pax
 DEPENDS+=	git-base-[0-9]*:../../devel/git-base
+BUILD_DEPENDS+=	nodejs:../../lang/nodejs
+BUILD_DEPENDS+=	npm:../../lang/npm
 
 EGDIR=		${PREFIX}/share/examples/gitea
 
@@ -50,13 +46,6 @@ PKG_USERS=	${GITEA_USER}:${GITEA_GROUP}
 PKG_SHELL.${GITEA_USER}=	${SH}
 PKG_HOME.${GITEA_USER}=		${VARBASE}/db/gitea
 
-SUBST_CLASSES+=			fix-version
-SUBST_STAGE.fix-version=	pre-configure
-SUBST_MESSAGE.fix-version=	Fix the outdated version number.
-SUBST_FILES.fix-version=	main.go
-SUBST_SED.fix-version=		-e 's,^\(	Version = \)"1\.9\.0-dev",\1"${PKGVERSION}",'
-SUBST_NOOP_OK.fix-version=	no
-
 SUBST_CLASSES+=		fix-var
 SUBST_STAGE.fix-var=	pre-configure
 SUBST_MESSAGE.fix-var=	Replace some vars
@@ -75,11 +64,20 @@ FILES_SUBST+=	GITEA_SHARE_DIR=${PREFIX}/share/gitea
 
 RCD_SCRIPTS+=	gitea
 
+MAKE_TARGET=	build
+MAKE_ENV+=	TAGS="${GO_TAGS}"
+
 pre-patch:
 	${CP} ${FILESDIR}/app.ini.sample ${WRKDIR}/
+	${CP} ${WRKDIR}/${DISTNAME}/.eslint* ${WRKSRC}/
+	${CP} ${WRKDIR}/${DISTNAME}/.stylelintrc ${WRKSRC}/
+	echo ${PKGVERSION_NOREV} > ${WRKSRC}/VERSION
+
+do-build:
+	cd ${WRKSRC} && ${BUILD_MAKE_CMD}
 
 do-install:
-	${INSTALL_PROGRAM} ${WRKDIR}/bin/gitea ${DESTDIR}${PREFIX}/sbin
+	${INSTALL_PROGRAM} ${WRKSRC}/gitea ${DESTDIR}${PREFIX}/sbin
 	cd ${WRKSRC}/options && ${PAX} -rw -pp . ${DESTDIR}${PREFIX}/share/gitea/options/
 	cd ${WRKSRC}/templates && ${PAX} -rw -pp . ${DESTDIR}${PREFIX}/share/gitea/templates/
 	cd ${WRKSRC}/public && ${PAX} -rw -pp . ${DESTDIR}${PREFIX}/share/gitea/public/

--- a/www/gitea/PLIST
+++ b/www/gitea/PLIST
@@ -660,6 +660,8 @@ share/gitea/options/locale/locale_zh-CN.ini
 share/gitea/options/locale/locale_zh-HK.ini
 share/gitea/options/locale/locale_zh-TW.ini
 share/gitea/options/readme/Default
+share/gitea/public/css/index.css
+share/gitea/public/css/theme-arc-green.css
 share/gitea/public/img/404.png
 share/gitea/public/img/500.png
 share/gitea/public/img/auth/bitbucket.png
@@ -690,6 +692,10 @@ share/gitea/public/img/openid-16x16.png
 share/gitea/public/img/repo_default.png
 share/gitea/public/img/slack.png
 share/gitea/public/img/telegram.png
+share/gitea/public/js/gitgraph.js
+share/gitea/public/js/gitgraph.js.map
+share/gitea/public/js/index.js
+share/gitea/public/js/index.js.map
 share/gitea/public/vendor/VERSIONS
 share/gitea/public/vendor/assets/font-awesome/LICENSE
 share/gitea/public/vendor/assets/font-awesome/css/LICENSE

--- a/www/gitea/distinfo
+++ b/www/gitea/distinfo
@@ -4,3 +4,4 @@ SHA1 (gitea-1.11.5.tar.gz) = bc8ca807775578f0ffdc73e8d8c68b28211878c4
 RMD160 (gitea-1.11.5.tar.gz) = 942aabda1f4efe5a9cc5778a2283558c2d97e39b
 SHA512 (gitea-1.11.5.tar.gz) = ba80ba77f6f761a03d062d5ceaacf0d2f9a7c5ad3c414f3d34ff31ee37ac00c4af562ecba0f14c6dca3ad2012e6cbfd8aea105dd87cfb06aedc80cf22a9ff12b
 Size (gitea-1.11.5.tar.gz) = 28249501 bytes
+SHA1 (patch-Makefile) = caa061ee349d4919994c4a3586299a149166e6d6

--- a/www/gitea/options.mk
+++ b/www/gitea/options.mk
@@ -7,6 +7,6 @@ PKG_SUGGESTED_OPTIONS=	sqlite
 .include "../../mk/bsd.options.mk"
 
 .if !empty(PKG_OPTIONS:Msqlite)
-GO_TAGS+=	sqlite sqlite_unlock_notify
+GO_TAGS+=	bindata sqlite sqlite_unlock_notify
 .include "../../databases/sqlite3/buildlink3.mk"
 .endif

--- a/www/gitea/patches/patch-Makefile
+++ b/www/gitea/patches/patch-Makefile
@@ -1,0 +1,13 @@
+$NetBSD$
+
+--- Makefile.orig	2020-05-09 19:26:27.000000000 +0000
++++ Makefile
+@@ -49,7 +49,7 @@ else
+ 	endif
+ endif
+ 
+-LDFLAGS := $(LDFLAGS) -X "main.MakeVersion=$(MAKE_VERSION)" -X "main.Version=$(GITEA_VERSION)" -X "main.Tags=$(TAGS)"
++LDFLAGS := -X "main.MakeVersion=$(MAKE_VERSION)" -X "main.Version=$(GITEA_VERSION)" -X "main.Tags=$(TAGS)"
+ 
+ PACKAGES ?= $(filter-out code.gitea.io/gitea/integrations/migration-test,$(filter-out code.gitea.io/gitea/integrations,$(shell GO111MODULE=on $(GO) list -mod=vendor ./... | grep -v /vendor/)))
+ 


### PR DESCRIPTION
This implements changes in the upstream build process and fixes the missing builtin static files in recent versions.

- Most important change is adding the missing `bindata` tag to `GO_TAGS` for integrating static files into the binary, [see upstream "install from source" docs](https://docs.gitea.io/en-us/install-from-source/)
- Switch from `go` to `gmake` and gitea's `Makefile` for building the package
- Added small patch to fix `LDFLAGS` where they shouldn't be
- `nodejs` and `npm` added as build dependencies
- `VERSION` file is used in the gitea's `Makefile` for baking the correct version into the binary