### PR TITLE
Update to Munin 2.0.69

### DIFF
--- a/sysutils/munin-common/Makefile.common
+++ b/sysutils/munin-common/Makefile.common
@@ -4,7 +4,7 @@
 # used by sysutils/munin-master/Makefile
 # used by sysutils/munin-node/Makefile
 
-VERSION=	2.0.67
+VERSION=	2.0.69
 DISTNAME=	munin-${VERSION}
 CATEGORIES=	sysutils
 MASTER_SITES=	${MASTER_SITE_SOURCEFORGE:=munin/}

--- a/sysutils/munin-common/distinfo
+++ b/sysutils/munin-common/distinfo
@@ -1,10 +1,12 @@
 $NetBSD: distinfo,v 1.7 2021/10/26 11:19:53 nia Exp $
 
-BLAKE2s (munin-2.0.67.tar.gz) = 208af60160d6ddfc98ae0d9c711bffce5d2c2c410710ab586a9a9c1fee00b11b
-SHA512 (munin-2.0.67.tar.gz) = 1f3766b52b99f625ff9cf4d3748a8935abed32b129d2a4714e37118e0116019bee3c1fd0e95da416fb3e39c9be9df17d11bca7f5a835be65ac5147e8b9858417
-Size (munin-2.0.67.tar.gz) = 2252301 bytes
+BLAKE2s (munin-2.0.69.tar.gz) = e1dbd5bf8ad7385c12de8ccfb4807aa2dcd9f2bd697068e8e027ae15fad45bbe
+SHA512 (munin-2.0.69.tar.gz) = e79c446d04df97d77b36972203667163ee662e0894e264c5dd84bd9402df780c5e67b69314bfdaddd87f102c4cdedb8fa7d2c07aeea46a8e4e9f08e50a08408f
+Size (munin-2.0.69.tar.gz) = 2250283 bytes
 SHA1 (patch-MANIFEST) = 538cec30723a6d41b732c9dc4a175472fb821609
 SHA1 (patch-Makefile) = f3fd52b56fcddda3efca61453c23243fac35568a
 SHA1 (patch-Makefile.config) = aeaae9374c58c6baf1901ddb9b55a8fac77cf30c
 SHA1 (patch-common_Build.PL) = 7d7f5afde978d0e5641f931d3f2585651ff40c1a
 SHA1 (patch-lib_Munin_Common_Defaults.pm) = 09b464d828e12da26d8f41916eb876863b4b4cb3
+SHA1 (patch-plugins_node.d.sunos_if__.in) = 6e78a8a7dfdab4ca4e98e1dbda8953b21a4fb645
+SHA1 (patch-plugins_node.d.sunos_if__err__.in) = 6cb57b118a4bb7124c4f8ac18da34c45e43b1d2a

--- a/sysutils/munin-common/patches/patch-plugins_node.d.sunos_if__.in
+++ b/sysutils/munin-common/patches/patch-plugins_node.d.sunos_if__.in
@@ -1,0 +1,20 @@
+$NetBSD$
+
+--- plugins/node.d.sunos/if_.in.orig	2021-11-22 22:12:17.000000000 +0000
++++ plugins/node.d.sunos/if_.in
+@@ -56,7 +56,7 @@ fi
+ 
+ if [ "$1" = "suggest" ]; then
+ 	if [ -x /usr/bin/kstat ]; then
+-		kstat -p -m '/^(?!unix)/' -n '/^(?!mac$)/' -s rbytes64 | awk -F: '{ print $3 }'
++		kstat -p -s rbytes64 | awk -F: '$3 != "mac" { print $3 }'
+ 		exit 0
+ 	else
+ 		exit 1
+@@ -87,5 +87,5 @@ if [ "$1" = "config" ]; then
+ 	exit 0
+ fi;
+ 
+-kstat -p -m '/^(?!unix)/' -n $INTERFACE -s '*bytes64' | sed \
++kstat -p -n $INTERFACE -s '*bytes64' | sed \
+ 	's/.*\(.bytes\)64./\1.value /'

--- a/sysutils/munin-common/patches/patch-plugins_node.d.sunos_if__err__.in
+++ b/sysutils/munin-common/patches/patch-plugins_node.d.sunos_if__err__.in
@@ -1,0 +1,24 @@
+$NetBSD$
+
+--- plugins/node.d.sunos/if_err_.in.orig	2021-11-22 22:12:17.000000000 +0000
++++ plugins/node.d.sunos/if_err_.in
+@@ -56,7 +56,7 @@ fi
+ 
+ if [ "$1" = "suggest" ]; then
+ 	if [ -x /usr/bin/kstat ]; then
+-		kstat -p -m '/^(?!unix)/' -n '/^(?!mac$)/' -s ierrors | awk -F: '{ print $3 }'
++		kstat -p -s ierrors | awk -F: '$1 != "unix" && $3 != "mac" { print $3 }'
+ 		exit 0
+ 	else
+ 		exit 1
+@@ -88,8 +88,8 @@ if [ "$1" = "config" ]; then
+ 	exit 0
+ fi
+ 
+-kstat -p -m '/^(?!unix)/' -n $INTERFACE -s '/^([io]errors|collisions)$/' | awk -F: '
+-{
++kstat -p -n $INTERFACE -s '/^([io]errors|collisions)$/' | awk -F: '
++$1 != "unix" {
+ 	split($4, four, "\t")
+ 	print four[1] ".value", four[2]
+ }'

--- a/sysutils/munin-node/PLIST
+++ b/sysutils/munin-node/PLIST
@@ -1,4 +1,4 @@
-@comment $NetBSD: PLIST,v 1.18 2021/07/25 13:26:36 tm Exp $
+@comment $NetBSD$
 bin/munin-get
 bin/munindoc
 lib/munin/plugins/amavis
@@ -14,6 +14,7 @@ lib/munin/plugins/courier_
 lib/munin/plugins/courier_mta_mailqueue
 lib/munin/plugins/courier_mta_mailstats
 lib/munin/plugins/courier_mta_mailvolume
+lib/munin/plugins/cpu
 lib/munin/plugins/cupsys_pages
 lib/munin/plugins/df
 lib/munin/plugins/df_inode
@@ -39,17 +40,25 @@ lib/munin/plugins/hddtemp_smartctl
 lib/munin/plugins/hddtempd
 lib/munin/plugins/hp2000_
 lib/munin/plugins/http_loadtime
+lib/munin/plugins/if_
+lib/munin/plugins/if_err_
 lib/munin/plugins/ifx_concurrent_sessions_
+lib/munin/plugins/io_busy_
+lib/munin/plugins/io_bytes_
+lib/munin/plugins/io_ops_
+lib/munin/plugins/iostat
 lib/munin/plugins/ipac-ng
 lib/munin/plugins/ipmi_
 lib/munin/plugins/ipmi_sensor_
 lib/munin/plugins/ircu
+lib/munin/plugins/load
 lib/munin/plugins/loggrep
 lib/munin/plugins/lpstat
 lib/munin/plugins/mailman
 lib/munin/plugins/mailscanner
 lib/munin/plugins/mbmon_
 lib/munin/plugins/memcached_
+lib/munin/plugins/memory
 lib/munin/plugins/mhttping
 lib/munin/plugins/multiping
 lib/munin/plugins/multips
@@ -80,6 +89,8 @@ lib/munin/plugins/nut_volts
 lib/munin/plugins/nutups_
 lib/munin/plugins/nvidia_
 lib/munin/plugins/openvpn
+lib/munin/plugins/paging_in
+lib/munin/plugins/paging_out
 lib/munin/plugins/perdition
 lib/munin/plugins/pgbouncer_connections
 lib/munin/plugins/pgbouncer_requests
@@ -167,11 +178,13 @@ lib/munin/plugins/squid_requests
 lib/munin/plugins/squid_traffic
 lib/munin/plugins/surfboard
 lib/munin/plugins/sybase_space
+lib/munin/plugins/temperature
 lib/munin/plugins/tomcat_
 lib/munin/plugins/tomcat_access
 lib/munin/plugins/tomcat_jvm
 lib/munin/plugins/tomcat_threads
 lib/munin/plugins/tomcat_volume
+lib/munin/plugins/uptime
 lib/munin/plugins/users
 lib/munin/plugins/varnish_
 lib/munin/plugins/vmstat


### PR DESCRIPTION
Here's an attempt to update to Munin 2.0.69 (latest 2.0.x, released a few months ago).

I've also applied 2 patches to make the `if_` plugins work on SmartOS (https://github.com/munin-monitoring/munin/commit/6b5f5ad4770f031dc98e74a066533e16db655751 and https://github.com/munin-monitoring/munin/commit/f5100a6eeb0340c2c6b3447f5a5569ae6ecf88d7, which are present in the Munin 2.1.x branch but not 2.0.x).

When I run `bmake package`, it builds a package that installs to `/opt/local`.  Could you point me to the process for building a package that installs to `/opt/tools` for SmartOS GZ?  (I wasn't able to find that info on the wiki.)