### PR TITLE
Patched erlang pubkey to make use of SmartOS default CA location

### DIFF
--- a/.github/workflows/create-quarterly-feature.yml
+++ b/.github/workflows/create-quarterly-feature.yml
@@ -1,0 +1,46 @@
+name: Create quarterly feature branches
+
+on:
+  workflow_dispatch:
+    inputs:
+      quarter:
+        description: 'Quarterly branch (e.g. 2025Q4)'
+        required: true
+
+jobs:
+  create-features:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        feature:
+          - macos
+          - miscfix
+          - pbulk
+          - pbulkmulti
+          - performance
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Configure github-actions bot
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch NetBSD/pkgsrc.git
+        run: |
+          git remote add netbsd https://github.com/NetBSD/pkgsrc.git
+          git fetch netbsd
+
+      - name: Create feature/${{ matrix.feature }}/${{ inputs.quarter }}
+        run: |
+          git checkout -B feature/${{ matrix.feature }}/${{ inputs.quarter }} origin/feature/${{ matrix.feature }}/trunk
+          git rebase --committer-date-is-author-date --onto netbsd/pkgsrc-${{ inputs.quarter }} netbsd/trunk
+
+      - name: Push feature/${{ matrix.feature }}/${{ inputs.quarter }}
+        run: |
+          git push --force origin feature/${{ matrix.feature }}/${{ inputs.quarter }}

--- a/.github/workflows/rebase-features.yml
+++ b/.github/workflows/rebase-features.yml
@@ -1,0 +1,45 @@
+name: Rebase feature branches against NetBSD
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        branch:
+          - feature/macos/trunk
+          - feature/miscfix/trunk
+          - feature/pbulk/trunk
+          - feature/pbulkmulti/trunk
+          - feature/performance/trunk
+          - trunk
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Configure github-actions bot
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch NetBSD/pkgsrc.git
+        run: |
+          git remote add netbsd https://github.com/NetBSD/pkgsrc.git
+          git fetch netbsd
+
+      - name: Rebase ${{ matrix.branch }}
+        run: |
+          git checkout ${{ matrix.branch }}
+          git rebase --committer-date-is-author-date netbsd/trunk
+
+      - name: Push ${{ matrix.branch }}
+        run: |
+          git push --force origin ${{ matrix.branch }}

--- a/.github/workflows/rebase-illumos.yml
+++ b/.github/workflows/rebase-illumos.yml
@@ -1,0 +1,35 @@
+name: Rebase illumos branch
+on:
+  workflow_dispatch:
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Configure github-actions bot
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Rebase release/trunk
+        run: |
+          git checkout release/trunk
+          git submodule update --init --recursive
+          git submodule foreach '
+            git fetch --all
+            main=$(git remote show origin | awk "/HEAD branch/ {print \$NF}")
+            git checkout $main
+            git pull
+          '
+          git reset --hard origin/feature/miscfix/trunk
+          for feature in pbulk pbulkmulti performance; do
+            git merge --no-edit origin/feature/${feature}/trunk
+          done
+          git submodule add https://github.com/TritonDataCenter/pkgsrc-extra.git extra
+          git submodule add https://github.com/TritonDataCenter/pkgsrc-joyent.git joyent
+          git submodule add https://github.com/TritonDataCenter/pkgsrc-wip.git wip
+          git add .gitmodules
+          git commit -m "Add submodules."
+          git push --force origin release/trunk

--- a/.github/workflows/rebase-macos.yml
+++ b/.github/workflows/rebase-macos.yml
@@ -1,0 +1,37 @@
+name: Rebase macOS branch
+on:
+  schedule:
+    - cron: "47 * * * *"
+  workflow_dispatch:
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Configure github-actions bot
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Rebase release/trunk
+        run: |
+          git checkout release/macos
+          git submodule update --init --recursive
+          git submodule foreach '
+            git fetch --all
+            main=$(git remote show origin | awk "/HEAD branch/ {print \$NF}")
+            git checkout $main
+            git pull
+          '
+          git reset --hard origin/feature/macos/trunk
+          git merge --no-edit origin/feature/performance/trunk
+          git submodule add https://github.com/TritonDataCenter/pkgsrc-extra.git extra
+          git add .gitmodules
+          git commit -m "Add submodules."
+          if [ "$(git rev-parse HEAD^{tree})" = "$(git rev-parse origin/release/macos^{tree})" ]; then
+            echo "No upstream changes, skipping push."
+            exit 0
+          fi
+          git push --force origin release/macos

--- a/lang/erlang/distinfo
+++ b/lang/erlang/distinfo
@@ -31,6 +31,7 @@ SHA1 (patch-lib_megaco_src_flex_Makefile.in) = 06eb5a76cc2e5adb4294c7db6919bb7c0
 SHA1 (patch-lib_megaco_src_flex_megaco__flex__scanner__drv.flex.src) = de57f4a94cdce3782592b4767a731b3693ba0224
 SHA1 (patch-lib_odbc_c__src_Makefile.in) = c34dd513e693839a8cf8cceac4655def300e7da4
 SHA1 (patch-lib_odbc_c__src_odbcserver.c) = 59960575f8ea8f6e65b2ad1f89632d48d40e2cfd
+SHA1 (patch-lib_public__key_src_pubkey__os__cacerts.erl) = 4e5cc27b86b3d4b431b54173ff24c25ed87ccb64
 SHA1 (patch-lib_runtime__tools_c__src_Makefile.in) = 98d351192902d5f6d3bd506c6e382caa06642383
 SHA1 (patch-make_otp.mk.in) = 9d1e33ab3660b5cf0faa2b74129158b71aae408f
 SHA1 (patch-make_output.mk.in) = d7b3da58bfb471d52c41242e2a03d1598ce24e62

--- a/lang/erlang/patches/patch-lib_public__key_src_pubkey__os__cacerts.erl
+++ b/lang/erlang/patches/patch-lib_public__key_src_pubkey__os__cacerts.erl
@@ -1,0 +1,14 @@
+$NetBSD$
+
+--- lib/public_key/src/pubkey_os_cacerts.erl.orig	2026-07-01 08:51:45.237156425 +0000
++++ lib/public_key/src/pubkey_os_cacerts.erl
+@@ -228,7 +228,8 @@ bsd_paths() ->
+ 
+ sunos_paths() ->
+     ["/etc/certs/CA/", %% Oracle Solaris, some older illumos distros
+-     "/etc/ssl/cacert.pem" %% OmniOS
++     "/etc/ssl/cacert.pem", %% OmniOS
++     "/etc/ssl/certs/ca-certificates.crt" %% SmartOS
+     ].
+ 
+ run_cmd(Cmd, Args) ->


### PR DESCRIPTION
Added `/etc/ssl/certs/ca-certificates.crt` to the CA cert search path for any platforms that identify as SunOS, which corrects the following error when attempting to use mix to download any libraries or dependencies:

```
# mix local.hex

20:25:04.589 [error] Task #PID<0.104.0> started from #PID<0.94.0> terminating
** (FunctionClauseError) no function clause matching in :pubkey_os_cacerts.conv_error_reason/1
    (public_key 1.21.2) pubkey_os_cacerts.erl:301: :pubkey_os_cacerts.conv_error_reason(:no_cacerts_found)
    (public_key 1.21.2) pubkey_os_cacerts.erl:56: :pubkey_os_cacerts.get/0
    (mix 1.20.2) lib/mix/utils.ex:883: Mix.Utils.read_httpc/1
    (mix 1.20.2) lib/mix/utils.ex:808: anonymous fn/2 in Mix.Utils.read_path/2
    (elixir 1.20.2) lib/task/supervised.ex:105: Task.Supervised.invoke_mfa/2
    (elixir 1.20.2) lib/task/supervised.ex:40: Task.Supervised.reply/4
Function: #Function<8.68880737/0 in Mix.Utils.read_path/2>
    Args: []
** (EXIT from #PID<0.94.0>) an exception was raised:
    ** (FunctionClauseError) no function clause matching in :pubkey_os_cacerts.conv_error_reason/1
        (public_key 1.21.2) pubkey_os_cacerts.erl:301: :pubkey_os_cacerts.conv_error_reason(:no_cacerts_found)
        (public_key 1.21.2) pubkey_os_cacerts.erl:56: :pubkey_os_cacerts.get/0
        (mix 1.20.2) lib/mix/utils.ex:883: Mix.Utils.read_httpc/1
        (mix 1.20.2) lib/mix/utils.ex:808: anonymous fn/2 in Mix.Utils.read_path/2
        (elixir 1.20.2) lib/task/supervised.ex:105: Task.Supervised.invoke_mfa/2
        (elixir 1.20.2) lib/task/supervised.ex:40: Task.Supervised.reply/4
```